### PR TITLE
Adjust Frozen Empire firing sounds

### DIFF
--- a/source/NeutronaWand/NeutronaWand.ino
+++ b/source/NeutronaWand/NeutronaWand.ino
@@ -2528,12 +2528,11 @@ void modeFireStartSounds() {
       if(getSystemYearMode() == SYSTEM_1989) {
         playEffect(S_FIRE_START_SPARK, false, i_volume_effects - 10, false, 0, false);
       }
+      else if(getSystemYearMode() == SYSTEM_FROZEN_EMPIRE) {
+        playEffect(S_FROZEN_EMPIRE_FIRE_START, false, i_volume_effects, false, 0, false);
+      }
       else {
         playEffect(S_FIRE_START_SPARK, false, i_volume_effects, false, 0, false);
-      }
-
-      if(getSystemYearMode() == SYSTEM_FROZEN_EMPIRE) {
-        playEffect(S_FROZEN_EMPIRE_FIRE_START, false, i_volume_effects, false, 0, false);
       }
 
       switch(i_power_level) {
@@ -2542,6 +2541,9 @@ void modeFireStartSounds() {
             if(getSystemYearMode() == SYSTEM_1989) {
               playEffect(S_GB2_FIRE_START, false, i_volume_effects, false, 0, false);
               playEffect(S_GB2_FIRE_LOOP, true, i_volume_effects, true, 6500, false);
+            }
+            else if(getSystemYearMode() == SYSTEM_FROZEN_EMPIRE) {
+              playEffect(S_GB1_FIRE_LOOP, true, i_volume_effects, true, 120, false);
             }
             else {
               playEffect(S_GB1_FIRE_START, false, i_volume_effects, false, 0, false);
@@ -2557,12 +2559,16 @@ void modeFireStartSounds() {
           if(b_firing_alt == true) {
             if(getSystemYearMode() == SYSTEM_1989) {
               playEffect(S_GB2_FIRE_START, false, i_volume_effects, false, 0, false);
+              playEffect(S_FIRING_LOOP_GB1, true, i_volume_effects, true, 1000, false);
+            }
+            else if(getSystemYearMode() == SYSTEM_FROZEN_EMPIRE) {
+              playEffect(S_FIRING_LOOP_GB1, true, i_volume_effects, true, 120, false);
             }
             else {
               playEffect(S_FIRE_START, false, i_volume_effects, false, 0, false);
+              playEffect(S_FIRING_LOOP_GB1, true, i_volume_effects, true, 1000, false);
             }
 
-            playEffect(S_FIRING_LOOP_GB1, true, i_volume_effects, true, 1000, false);
             b_sound_firing_alt_trigger = true;
           }
           else {
@@ -2581,8 +2587,11 @@ void modeFireStartSounds() {
               playEffect(S_GB1_FIRE_START, false, i_volume_effects, false, 0, false);
             break;
 
-            case SYSTEM_AFTERLIFE:
             case SYSTEM_FROZEN_EMPIRE:
+              // Do nothing.
+            break;
+
+            case SYSTEM_AFTERLIFE:
             default:
             {
               uint8_t i_amplify_tmp = 2;
@@ -2599,7 +2608,12 @@ void modeFireStartSounds() {
           if(b_firing_intensify == true) {
             // Reset some sound triggers.
             b_sound_firing_intensify_trigger = true;
-            playEffect(S_GB1_FIRE_HIGH_POWER_LOOP, true, i_volume_effects, true, 700, false);
+            if(getSystemYearMode() == SYSTEM_FROZEN_EMPIRE) {
+              playEffect(S_GB1_FIRE_HIGH_POWER_LOOP, true, i_volume_effects, true, 120, false);
+            }
+            else {
+              playEffect(S_GB1_FIRE_HIGH_POWER_LOOP, true, i_volume_effects, true, 700, false);
+            }
           }
           else {
             b_sound_firing_intensify_trigger = false;
@@ -2608,8 +2622,12 @@ void modeFireStartSounds() {
           if(b_firing_alt == true) {
             // Reset some sound triggers.
             b_sound_firing_alt_trigger = true;
-
-            playEffect(S_FIRING_LOOP_GB1, true, i_volume_effects, true, 700, false);
+            if(getSystemYearMode() == SYSTEM_FROZEN_EMPIRE) {
+              playEffect(S_FIRING_LOOP_GB1, true, i_volume_effects, true, 120, false);
+            }
+            else {
+              playEffect(S_FIRING_LOOP_GB1, true, i_volume_effects, true, 700, false);
+            }
           }
           else {
             b_sound_firing_alt_trigger = false;

--- a/source/ProtonPack/ProtonPack.ino
+++ b/source/ProtonPack/ProtonPack.ino
@@ -3932,12 +3932,11 @@ void modeFireStartSounds() {
       if(SYSTEM_YEAR == SYSTEM_1989) {
         playEffect(S_FIRE_START_SPARK, false, i_volume_effects - 10, false, 0, false);
       }
+      else if(SYSTEM_YEAR == SYSTEM_FROZEN_EMPIRE) {
+        playEffect(S_FROZEN_EMPIRE_FIRE_START, false, i_volume_effects, false, 0, false);
+      }
       else {
         playEffect(S_FIRE_START_SPARK, false, i_volume_effects, false, 0, false);
-      }
-
-      if(SYSTEM_YEAR == SYSTEM_FROZEN_EMPIRE) {
-        playEffect(S_FROZEN_EMPIRE_FIRE_START, false, i_volume_effects, false, 0, false);
       }
 
       switch(i_wand_power_level) {
@@ -3946,6 +3945,9 @@ void modeFireStartSounds() {
             if(SYSTEM_YEAR == SYSTEM_1989) {
               playEffect(S_GB2_FIRE_LOOP, true, i_volume_effects, true, 6500, false);
               playEffect(S_GB2_FIRE_START, false, i_volume_effects, false, 0, false);
+            }
+            else if(SYSTEM_YEAR == SYSTEM_FROZEN_EMPIRE) {
+              playEffect(S_GB1_FIRE_LOOP, true, i_volume_effects, true, 120, false);
             }
             else {
               playEffect(S_GB1_FIRE_LOOP, true, i_volume_effects, true, 1000, false);
@@ -3961,12 +3963,16 @@ void modeFireStartSounds() {
           if(b_firing_alt == true) {
             if(SYSTEM_YEAR == SYSTEM_1989) {
               playEffect(S_GB2_FIRE_START, false, i_volume_effects, false, 0, false);
+              playEffect(S_FIRING_LOOP_GB1, true, i_volume_effects, true, 1000, true);
+            }
+            else if(SYSTEM_YEAR == SYSTEM_FROZEN_EMPIRE) {
+              playEffect(S_FIRING_LOOP_GB1, true, i_volume_effects, true, 120, true);
             }
             else {
               playEffect(S_FIRE_START, false, i_volume_effects, false, 0, false);
+              playEffect(S_FIRING_LOOP_GB1, true, i_volume_effects, true, 1000, true);
             }
 
-            playEffect(S_FIRING_LOOP_GB1, true, i_volume_effects, true, 1000, true);
             b_sound_firing_alt_trigger = true;
           }
           else {
@@ -3985,8 +3991,11 @@ void modeFireStartSounds() {
               playEffect(S_GB1_FIRE_START, false, i_volume_effects, false, 0, false);
             break;
 
-            case SYSTEM_AFTERLIFE:
             case SYSTEM_FROZEN_EMPIRE:
+              // Do nothing.
+            break;
+
+            case SYSTEM_AFTERLIFE:
             default:
               playEffect(S_AFTERLIFE_FIRE_START, false, i_volume_effects, false, 0, false);
             break;
@@ -3995,7 +4004,12 @@ void modeFireStartSounds() {
           if(b_firing_intensify == true) {
             // Reset some sound triggers.
             b_sound_firing_intensify_trigger = true;
-            playEffect(S_GB1_FIRE_HIGH_POWER_LOOP, true, i_volume_effects, true, 700, false);
+            if(SYSTEM_YEAR == SYSTEM_FROZEN_EMPIRE) {
+              playEffect(S_GB1_FIRE_HIGH_POWER_LOOP, true, i_volume_effects, true, 120, false);
+            }
+            else {
+              playEffect(S_GB1_FIRE_HIGH_POWER_LOOP, true, i_volume_effects, true, 700, false);
+            }
           }
           else {
             b_sound_firing_intensify_trigger = false;
@@ -4004,8 +4018,12 @@ void modeFireStartSounds() {
           if(b_firing_alt == true) {
             // Reset some sound triggers.
             b_sound_firing_alt_trigger = true;
-
-            playEffect(S_FIRING_LOOP_GB1, true, i_volume_effects, true, 700, false);
+            if(SYSTEM_YEAR == SYSTEM_FROZEN_EMPIRE) {
+              playEffect(S_FIRING_LOOP_GB1, true, i_volume_effects, true, 120, false);
+            }
+            else {
+              playEffect(S_FIRING_LOOP_GB1, true, i_volume_effects, true, 700, false);
+            }
           }
           else {
             b_sound_firing_alt_trigger = false;
@@ -4022,7 +4040,7 @@ void modeFireStartSounds() {
 
     case STASIS:
       stopEffect(S_STASIS_END);
-      playEffect(S_STASIS_START);
+      playEffect(S_STASIS_START, false, i_volume_effects, false, 0, false);
       playEffect(S_STASIS_LOOP, true, i_volume_effects, true, 1000, false);
     break;
 


### PR DESCRIPTION
Adjusts how the Frozen Empire fire start sound works to make it more prominent, closer to how it was heard in the film.