### PR TITLE
Ribbon cable alarm refactor

### DIFF
--- a/source/NeutronaWand/Header.h
+++ b/source/NeutronaWand/Header.h
@@ -257,25 +257,20 @@ const uint8_t d_bargraph_ramp_interval = 120;
 uint8_t i_bargraph_status = 0;
 
 /*
- * (Optional) Barmeter 28 segment bargraph configuration and timers.
+ * (Optional) Barmeter 28-segment bargraph configuration and timers.
  * Part #: BL28Z-3005SA04Y
  */
 HT16K33 ht_bargraph;
 
-// Used to scan the i2c bus and to locate the 28 segment bargraph.
+// Used to scan the i2c bus and to locate the 28-segment bargraph.
 #define WIRE Wire
 
 /*
- * Set to true if you are replacing the stock Hasbro bargraph with a Barmeter 28 segment bargraph.
- * Set to false if you are using the stock Hasbro bargraph.
+ * Used to change to 28-segment bargraph features.
+ * The Frutto 28-segment bargraph is automatically detected on boot and sets this to true.
  * Part #: BL28Z-3005SA04Y
  */
 bool b_28segment_bargraph = false;
-
-/*
- * Flag check for video game mode.
- */
-bool b_vg_mode = true;
 
 const uint8_t i_bargraph_interval = 4;
 const uint8_t i_bargraph_wait = 180;
@@ -288,7 +283,7 @@ const uint8_t i_bargraph_multiplier_ramp_2021 = 16;
 unsigned int i_bargraph_multiplier_current = i_bargraph_multiplier_ramp_2021;
 
 /*
- * (Optional) Barmeter 28 segment bargraph mapping.
+ * (Optional) Barmeter 28-segment bargraph mapping.
  * Part #: BL28Z-3005SA04Y
 
  * Segment Layout:
@@ -303,6 +298,11 @@ uint8_t i_bargraph[i_bargraph_segments] = {};
 const uint8_t i_bargraph_invert[i_bargraph_segments] = {54, 38, 22, 6, 53, 37, 21, 5, 52, 36, 20, 4, 51, 35, 19, 3, 50, 34, 18, 2, 49, 33, 17, 1, 48, 32, 16, 0};
 const uint8_t i_bargraph_normal[i_bargraph_segments] = {0, 16, 32, 48, 1, 17, 33, 49, 2, 18, 34, 50, 3, 19, 35, 51, 4, 20, 36, 52, 5, 21, 37, 53, 6, 22, 38, 54};
 bool b_bargraph_status[i_bargraph_segments] = {};
+
+/*
+ * Flag check for video game mode.
+ */
+bool b_vg_mode = true;
 
 /*
  * (Optional) Support for Video Game Accessories (coming soon)
@@ -378,7 +378,6 @@ enum WAND_CONN_STATES WAND_CONN_STATE;
  */
 bool b_pack_on = false; // Denotes the pack has been powered on.
 bool b_pack_alarm = false; // Denotes the pack alarm is sounding (ribbon cable disconnected).
-bool b_pack_ribbon_cable_on = true; // Denotes that the pack's ribbon cable is connected.
 bool b_pack_ion_arm_switch_on = false; // For MODE_ORIGINAL. Lets us know if the Proton Pack Ion Arm switch is on to give power to the pack & wand.
 bool b_sync_light = false; // Toggle for the state of the white LED beside the vent light which gets blinked as a sync operation is attempted.
 uint8_t i_cyclotron_speed_up = 1; // For telling the pack to speed up or slow down the Cyclotron lights.

--- a/source/NeutronaWand/NeutronaWand.ino
+++ b/source/NeutronaWand/NeutronaWand.ino
@@ -227,7 +227,7 @@ void loop() {
     break;
 
     case SYNCHRONIZING:
-      // Currently unused
+      // Currently unused.
       checkPack(); // Keep checking for responses from the pack while synchronizing.
     break;
 
@@ -334,7 +334,7 @@ void mainLoop() {
             wandSerialSend(W_SETTINGS_MODE);
           }
           else {
-            // Only exit the settings menu when on menu #5 in the top menu or the pack alarm is active.
+            // Only exit the settings menu when on menu #5 in the top menu or the pack ribbon cable alarm is active.
             if(i_wand_menu == 5 && WAND_MENU_LEVEL == MENU_LEVEL_1 && FIRING_MODE == SETTINGS) {
               wandExitMenu();
             }
@@ -1531,7 +1531,7 @@ void wandOff() {
       b_wand_mash_error = false;
     }
 
-    if(b_pack_ribbon_cable_on == true) {
+    if(b_pack_alarm != true) {
       switch(getNeutronaWandYearMode()) {
         case SYSTEM_1984:
         case SYSTEM_1989:
@@ -2147,7 +2147,7 @@ void postActivation() {
 
           soundIdleLoop(true);
 
-          if(switch_vent.on() == false && b_pack_ribbon_cable_on == true) {
+          if(switch_vent.on() == false && b_pack_alarm != true) {
             afterLifeRamp1();
           }
         break;
@@ -2283,32 +2283,30 @@ void soundIdleStart() {
         stopEffect(S_AFTERLIFE_WAND_RAMP_DOWN_2);
         stopEffect(S_AFTERLIFE_WAND_RAMP_DOWN_2_FADE_OUT);
 
-        if(b_pack_ribbon_cable_on == true) {
-          if(b_sound_afterlife_idle_2_fade == true) {
-            playEffect(S_AFTERLIFE_WAND_RAMP_2_FADE_IN, false, i_volume_effects - 1);
+        if(b_sound_afterlife_idle_2_fade == true) {
+          playEffect(S_AFTERLIFE_WAND_RAMP_2_FADE_IN, false, i_volume_effects - 1);
 
-            if(b_extra_pack_sounds == true) {
-              wandSerialSend(W_EXTRA_WAND_SOUNDS_STOP);
+          if(b_extra_pack_sounds == true) {
+            wandSerialSend(W_EXTRA_WAND_SOUNDS_STOP);
 
-              wandSerialSend(W_AFTERLIFE_GUN_RAMP_2_FADE_IN);
-            }
-
-            b_sound_afterlife_idle_2_fade = false;
-          }
-          else {
-            playEffect(S_AFTERLIFE_WAND_RAMP_2, false, i_volume_effects - 1);
-
-            if(b_extra_pack_sounds == true) {
-              wandSerialSend(W_EXTRA_WAND_SOUNDS_STOP);
-
-              wandSerialSend(W_AFTERLIFE_GUN_RAMP_2);
-            }
+            wandSerialSend(W_AFTERLIFE_GUN_RAMP_2_FADE_IN);
           }
 
-          ms_gun_loop_2.start(i_gun_loop_2);
-
-          b_sound_idle = true;
+          b_sound_afterlife_idle_2_fade = false;
         }
+        else {
+          playEffect(S_AFTERLIFE_WAND_RAMP_2, false, i_volume_effects - 1);
+
+          if(b_extra_pack_sounds == true) {
+            wandSerialSend(W_EXTRA_WAND_SOUNDS_STOP);
+
+            wandSerialSend(W_AFTERLIFE_GUN_RAMP_2);
+          }
+        }
+
+        ms_gun_loop_2.start(i_gun_loop_2);
+
+        b_sound_idle = true;
 
         ms_gun_loop_1.stop();
       break;
@@ -2360,7 +2358,7 @@ void soundIdleStop() {
           wandSerialSend(W_AFTERLIFE_RAMP_LOOP_2_STOP);
         }
 
-        if(b_pack_ribbon_cable_on == true) {
+        if(b_pack_alarm != true) {
           if(WAND_ACTION_STATUS == ACTION_OVERHEATING || b_pack_alarm == true) {
             playEffect(S_AFTERLIFE_WAND_RAMP_DOWN_2_FADE_OUT, false, i_volume_effects - 1);
 

--- a/source/NeutronaWand/Serial.h
+++ b/source/NeutronaWand/Serial.h
@@ -105,7 +105,6 @@ struct __attribute__((packed)) SyncData {
   uint8_t systemMode;
   uint8_t ionArmSwitch;
   uint8_t systemYear;
-  uint8_t ribbonCable;
   uint8_t packOn;
   uint8_t powerLevel;
   uint8_t firingMode;
@@ -629,17 +628,6 @@ void checkPack() {
           // Reset the white LED blink rate in case we changed wand year.
           resetWhiteLEDBlinkRate();
 
-          // Set whether the ribbon cable on the Pack is connected or not.
-          switch(packSync.ribbonCable) {
-            case 1:
-              b_pack_ribbon_cable_on = false;
-            break;
-            case 2:
-            default:
-              b_pack_ribbon_cable_on = true;
-            break;
-          }
-
           // Set whether the Proton Pack is currently on or off.
           switch(packSync.packOn) {
             case 1:
@@ -1011,11 +999,13 @@ bool handlePackCommand(uint8_t i_command, uint16_t i_value) {
     break;
 
     case P_RIBBON_CABLE_ON:
-      b_pack_ribbon_cable_on = true;
+      // Currently unused.
+      //b_pack_ribbon_cable_on = true;
     break;
 
     case P_RIBBON_CABLE_OFF:
-      b_pack_ribbon_cable_on = false;
+      // Currently unused.
+      //b_pack_ribbon_cable_on = false;
     break;
 
     case P_ALARM_ON:
@@ -1038,7 +1028,7 @@ bool handlePackCommand(uint8_t i_command, uint16_t i_value) {
         ms_hat_2.start(i_hat_2_delay); // Start the hat light 2 blinking timer.
       }
 
-      if(WAND_STATUS == MODE_ON && b_pack_ribbon_cable_on != true && WAND_ACTION_STATUS != ACTION_OVERHEATING) {
+      if(WAND_STATUS == MODE_ON && WAND_ACTION_STATUS != ACTION_OVERHEATING) {
         switch(getNeutronaWandYearMode()) {
           case SYSTEM_1984:
           case SYSTEM_1989:
@@ -1076,16 +1066,12 @@ bool handlePackCommand(uint8_t i_command, uint16_t i_value) {
           switch(SYSTEM_MODE) {
             case MODE_ORIGINAL:
               if(switch_vent.on() == true && switch_wand.on() == true && switch_activate.on() == true && b_pack_alarm == true) {
-                b_pack_alarm = false;
-
                 prepBargraphRampUp();
               }
             break;
 
             case MODE_SUPER_HERO:
             default:
-              b_pack_alarm = false;
-
               prepBargraphRampUp();
             break;
           }
@@ -1095,7 +1081,7 @@ bool handlePackCommand(uint8_t i_command, uint16_t i_value) {
       // Alarm is off.
       b_pack_alarm = false;
 
-      if(WAND_STATUS == MODE_ON && b_pack_ribbon_cable_on == true && WAND_ACTION_STATUS != ACTION_OVERHEATING) {
+      if(WAND_STATUS == MODE_ON && WAND_ACTION_STATUS != ACTION_OVERHEATING) {
         soundIdleLoop(true);
 
         if(getNeutronaWandYearMode() == SYSTEM_AFTERLIFE || getNeutronaWandYearMode() == SYSTEM_FROZEN_EMPIRE) {


### PR DESCRIPTION
This PR cleans up the handling of the pack's ribbon cable to be more reliable, and fixes some calls that could have resulted in incorrect behavior in edge cases.

As it got rid of an entire variable wand-side, got rid of a sync variable between both wand and pack, and refactored a lot of the cable handling pack-side this needs a quick test to make sure nothing got overlooked. However since A_ALARM_ON/P_ALARM_ON are only sent for ribbon cable events and never for overheating (because the wand controls overheating with W_OVERHEATING so that version of the pack alarm does not send serial data) this more condensed version should actually be a little more efficient.