### PR TITLE
Fix Compile Tests

### DIFF
--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -10,8 +10,8 @@ jobs:
   compile-mega:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: arduino/compile-sketches@v1
+      - uses: actions/checkout@main
+      - uses: arduino/compile-sketches@main
         with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
             enable-deltas-report: true
@@ -39,8 +39,8 @@ jobs:
   compile-nano:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: arduino/compile-sketches@v1
+      - uses: actions/checkout@main
+      - uses: arduino/compile-sketches@main
         with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
             enable-deltas-report: true
@@ -64,11 +64,14 @@ jobs:
   compile-esp32:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: arduino/compile-sketches@v1
+      - uses: actions/checkout@main
+      - uses: arduino/compile-sketches@main
         with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
             enable-deltas-report: true
+            platforms: |
+              - name: "esp32:esp32"
+                version: "2.0.17"
             fqbn: esp32:esp32:esp32
             sketch-paths: |
               - source/Attenuator

--- a/WIRELESS_OPERATION.md
+++ b/WIRELESS_OPERATION.md
@@ -21,8 +21,6 @@ In order to view the state of the pack and control it remotely, the two devices 
 
 ## Web Interface
 
-<img style="float:right;padding:10px;width:300px;" src="images/WebUI-Main1.jpg"/>
-
 When using the ESP32 controller for either the Attenuator or Wireless Adapter, it will offer a private WiFi network which begins with the prefix **"ProtonPack_"** and secured with a default password of **"555-2368"**.
 
 Once connected, your computer/phone/table should be assigned an IP address starting from **"192.168.1.100"** with a subnet of **"255.255.255.0"**. Please remember that if you intend to have multiple devices connect via this private WiFi network you will be assigned a unique IP address for each device.
@@ -31,9 +29,11 @@ A web-based user interface is available at [http://192.168.1.2](http://192.168.1
 
 ### Tab 1: Equipment Status
 
+<img style="float:right;padding:10px;width:300px;" src="images/WebUI-Main1.jpg"/>
+
 The equipment status will reflect the current state of your Proton Pack and Neutrona Wand and will update in real-time as you interact with those devices. This information is available as either a text-based or graphical display, or both if you prefer (set via Attenuator Preferences).
 
-**Note:** If you see a "&mdash;" (dash) beside these values it can indicate a potential communication issue. Simply refresh the page and/or check your WiFi connection to the device.
+**Note:** When using the text-based display, if you see a "&mdash;" (dash) beside the labels it can indicate a potential communication issue. Simply refresh the page and/or check your WiFi connection to the device. In rare cases you may need to do a reboot of the ESP32 device via the admin tab.
 
 Special thanks and credit to fellow cosplayer [Alexander Hibbs (@BeaulieuDesigns87)](https://www.etsy.com/shop/BeaulieuDesigns87) from the [South Carolina Ghostbusters](https://www.facebook.com/SCGhostbusters/), who created the amazingly detailed Proton Pack and Neutrona Wand technical illustration, available as a [printed poster](https://www.etsy.com/listing/1406461576/proton-pack-blueprint-matte-poster) or [digital image](https://www.etsy.com/listing/1411559802/proton-pack-blueprint-digital-download). He has graciously provided a version of his design to make the new graphical interface.
 


### PR DESCRIPTION
This primarily forces the compilation tests to use the esp32 library at version 2.0.17 until such time that the other libraries catch up to changes from the new v3.0.0 release. The newest seems to cause some issues with our required libraries (as best I can tell) but seems the devs are aware and working on it...I hope.

In the meantime, if using Arduino IDE do not let it update to the latest espressif/arduino-esp32 library or your compiles will fail there as well. That change is more impactful to building of the binaries, while the compile-test.yml is just a sanity check.