### PR TITLE
Correct EEPROM LED checks

### DIFF
--- a/source/NeutronaWand/include/Header.h
+++ b/source/NeutronaWand/include/Header.h
@@ -157,8 +157,13 @@ const uint8_t frutto_barrel[48] PROGMEM = {0, 25, 24, 48, 1, 26, 23, 47, 2, 27, 
  * Supported options: Stock (5), GPStar Neturona Barrel (48 + 2 Strobe Tips), GPStar Barrel LED Mini (2) and Frutto Technology (48 + Strobe Tip)
  */
 uint8_t i_num_barrel_leds = 5;
-enum WAND_BARREL_LED_COUNTS { LEDS_5, LEDS_48, LEDS_50, LEDS_2 };
-enum WAND_BARREL_LED_COUNTS WAND_BARREL_LED_COUNT;
+enum WAND_BARREL_LED_COUNTS : uint8_t {
+  LEDS_UNKNOWN = 0,
+  LEDS_2 = 2,
+  LEDS_5 = 5,
+  LEDS_48 = 48,
+  LEDS_50 = 50
+} WAND_BARREL_LED_COUNT;
 
 /*
  * Delay for fastled to update the addressable LEDs.
@@ -301,9 +306,13 @@ HT16K33 ht_bargraph;
  * The Frutto 28-segment bargraph is automatically detected on boot and sets this to true.
  * Part #: BL28Z-3005SA04Y
  */
-enum BARGRAPH_TYPES { SEGMENTS_5, SEGMENTS_28, SEGMENTS_30 };
-enum BARGRAPH_TYPES BARGRAPH_TYPE;
-enum BARGRAPH_TYPES BARGRAPH_TYPE_EEPROM;
+enum BARGRAPH_TYPES : uint8_t {
+  SEGMENTS_UNKNOWN = 0,
+  SEGMENTS_5 = 5,
+  SEGMENTS_28 = 28,
+  SEGMENTS_30 = 30
+} BARGRAPH_TYPE;
+BARGRAPH_TYPES BARGRAPH_TYPE_EEPROM = SEGMENTS_28;
 
 const uint8_t i_bargraph_interval = 4;
 const uint8_t i_bargraph_wait = 180;

--- a/source/NeutronaWand/include/Preferences.h
+++ b/source/NeutronaWand/include/Preferences.h
@@ -429,8 +429,8 @@ void readEEPROM() {
       i_spectral_wand_custom_saturation = obj_led_eeprom.barrel_spectral_saturation_custom;
     }
 
-    if(obj_led_eeprom.num_barrel_leds == 2 || obj_led_eeprom.num_barrel_leds == 5 ||
-      obj_led_eeprom.num_barrel_leds == 48 || obj_led_eeprom.num_barrel_leds == 50) {
+    if(obj_led_eeprom.num_barrel_leds == LEDS_2 || obj_led_eeprom.num_barrel_leds == LEDS_5 ||
+      obj_led_eeprom.num_barrel_leds == LEDS_48 || obj_led_eeprom.num_barrel_leds == LEDS_50) {
       i_num_barrel_leds = obj_led_eeprom.num_barrel_leds;
 
       switch(i_num_barrel_leds) {
@@ -454,7 +454,7 @@ void readEEPROM() {
       }
     }
 
-    if(obj_led_eeprom.num_bargraph_leds == 28 || obj_led_eeprom.num_bargraph_leds == 30) {
+    if(obj_led_eeprom.num_bargraph_leds == SEGMENTS_28 || obj_led_eeprom.num_bargraph_leds == SEGMENTS_30) {
       if(obj_led_eeprom.num_bargraph_leds < 30) {
         BARGRAPH_TYPE_EEPROM = SEGMENTS_28;
       }
@@ -463,7 +463,9 @@ void readEEPROM() {
       }
 
       // Only override the bargraph LED count if we are not using a stock bargraph.
-      BARGRAPH_TYPE = BARGRAPH_TYPE_EEPROM;
+      if(BARGRAPH_TYPE != SEGMENTS_5) {
+        BARGRAPH_TYPE = BARGRAPH_TYPE_EEPROM;
+      }
     }
 
     if(obj_led_eeprom.rgb_vent_light > 0 && obj_led_eeprom.rgb_vent_light < 3) {
@@ -498,23 +500,9 @@ void clearLEDEEPROM() {
 void saveLEDEEPROM() {
   uint16_t i_eepromLEDAddress = i_eepromAddress + sizeof(objConfigEEPROM);
 
-  uint8_t i_barrel_led_count = 5; // 5 = Hasbro, 50 = GPStar Neutrona Barrel, 2 = GPStar Barrel LED Mini, 48 = Frutto.
-  uint8_t i_bargraph_led_count = 28; // 28 segment, 30 segment.
+  uint8_t i_barrel_led_count = WAND_BARREL_LED_COUNT; // 5 = Hasbro, 50 = GPStar Neutrona Barrel, 2 = GPStar Barrel LED Mini, 48 = Frutto.
+  uint8_t i_bargraph_led_count = BARGRAPH_TYPE_EEPROM; // 28 segment, 30 segment.
   uint8_t i_rgb_vent_light = 1; // 1 = RGB Vent Light disabled, 2 = RGB Vent Light enabled
-
-  if(WAND_BARREL_LED_COUNT == LEDS_48) {
-    i_barrel_led_count = 48;
-  }
-  else if(WAND_BARREL_LED_COUNT == LEDS_50) {
-    i_barrel_led_count = 50;
-  }
-  else if(WAND_BARREL_LED_COUNT == LEDS_2) {
-    i_barrel_led_count = 2;
-  }
-
-  if(BARGRAPH_TYPE_EEPROM == SEGMENTS_30) {
-    i_bargraph_led_count = 30;
-  }
 
   if(b_rgb_vent_light) {
     i_rgb_vent_light = 2;

--- a/source/NeutronaWand/include/Preferences.h
+++ b/source/NeutronaWand/include/Preferences.h
@@ -429,8 +429,8 @@ void readEEPROM() {
       i_spectral_wand_custom_saturation = obj_led_eeprom.barrel_spectral_saturation_custom;
     }
 
-    if(obj_led_eeprom.num_barrel_leds == LEDS_2 || obj_led_eeprom.num_barrel_leds == LEDS_5 ||
-      obj_led_eeprom.num_barrel_leds == LEDS_48 || obj_led_eeprom.num_barrel_leds == LEDS_50) {
+    if(obj_led_eeprom.num_barrel_leds == 2 || obj_led_eeprom.num_barrel_leds == 5 ||
+      obj_led_eeprom.num_barrel_leds == 48 || obj_led_eeprom.num_barrel_leds == 50) {
       i_num_barrel_leds = obj_led_eeprom.num_barrel_leds;
 
       switch(i_num_barrel_leds) {
@@ -454,7 +454,7 @@ void readEEPROM() {
       }
     }
 
-    if(obj_led_eeprom.num_bargraph_leds == SEGMENTS_28 || obj_led_eeprom.num_bargraph_leds == SEGMENTS_30) {
+    if(obj_led_eeprom.num_bargraph_leds == 28 || obj_led_eeprom.num_bargraph_leds == 30) {
       if(obj_led_eeprom.num_bargraph_leds < 30) {
         BARGRAPH_TYPE_EEPROM = SEGMENTS_28;
       }
@@ -506,7 +506,7 @@ void saveLEDEEPROM() {
     i_barrel_led_count = 48;
   }
   else if(WAND_BARREL_LED_COUNT == LEDS_50) {
-    i_barrel_led_count = 50; // Needs to be a 50. However we change it back to 48 after it is saved to the EEPROM.
+    i_barrel_led_count = 50;
   }
   else if(WAND_BARREL_LED_COUNT == LEDS_2) {
     i_barrel_led_count = 2;
@@ -533,10 +533,6 @@ void saveLEDEEPROM() {
   EEPROM.put(i_eepromLEDAddress, obj_led_eeprom);
 
   updateCRCEEPROM();
-
-  if(WAND_BARREL_LED_COUNT == LEDS_50) {
-    i_barrel_led_count = 48; // Needs to be reset back to 48 while 50 is stored in the EEPROM. 2 are for the tip.
-  }
 }
 
 void clearConfigEEPROM() {


### PR DESCRIPTION
Corrects logic error where EEPROM LED checks were checking against a raw enum rather than an absolute value, causing the checks for the wand barrel LED count and bargraph segment count to fail to read correctly after a power cycle.

This bug was introduced when hardening of EEPROM values was introduced alongside 6.0.1/5.4.Bugfix and as such after being merged with `main` must be upstreamed to `5.4.Fixes` and `6.1.Dev`, then all three branches should have binaries rebuilt and a new 6.0.1 released to replace the existing version.